### PR TITLE
fixed list block config in bodyPortableText

### DIFF
--- a/studio/schemas/objects/bodyPortableText.js
+++ b/studio/schemas/objects/bodyPortableText.js
@@ -18,7 +18,7 @@ export default {
         {title: 'H4', value: 'h4'},
         {title: 'Quote', value: 'blockquote'}
       ],
-      lists: [{title: 'Bullet', value: 'bullet'}, {title: 'Numbered', value: 'numbered'}],
+      lists: [{title: 'Bullet', value: 'bullet'}, {title: 'Numbered', value: 'number'}],
       // Marks let you mark up inline text in the block editor.
       marks: {
         // Decorators usually describe a single property – e.g. a typographic


### PR DESCRIPTION
updated to match Sanity.io docs  {title: 'Numbered', value: 'number'}